### PR TITLE
increase request version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "main": "./phaxio.js",
   "dependencies": {
-  	"request": "2.10.x",
+  	"request": "2.16.x",
   	"mime": "1.2.x"
   }
 }


### PR DESCRIPTION
We were having socket hangup errors in phaxio `provisionNumber` when we upgraded to Node 0.8.21. I believe we were seeing the socket issue raised by a bug fixed in 0.8.20. Here's a good summary:

http://clock.co.uk/tech-blogs/preventing-http-raise-hangup-error-on-destroyed-socket-write-from-crashing-your-nodejs-server

Increasing request version for phaxio to the current one seemed to have resolved the issue for us.
