### PR TITLE
Revisting the hangup issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "name": "phaxio",
   "description": "Send faxes with the Phaxio API",
   "keywords": ["fax", "phaxio"],
-  "version": "0.0.5",
+  "version": "0.0.6",
   "homepage": "https://github.com/chadsmith/node-phaxio",
   "repository": {
     "type": "git",

--- a/phaxio.js
+++ b/phaxio.js
@@ -139,7 +139,8 @@ Phaxio.prototype.request = function(resource, opt, cb) {
     uri: this.host + this.endpoint + resource,
     headers: { 'content-type': 'multipart/form-data;' },
     multipart: multipart,
-    encoding: 'binary'
+    encoding: 'binary',
+    agent: false
   };
 
   var responceCb = function(err, res, body) {


### PR DESCRIPTION
So we were getting the socket hangup issue again. Turns out it wasn't the request version and the socket hangup related to node 0.8.20 like I had previously thought. After digging deeper, I believe it is related to the way node does agent pooling for http(s). Some more info:

https://github.com/substack/hyperquest
mikeal/request#465
mikeal/request#259
mikeal/request#467

Seems the issue will be addressed in 0.12. This seems like a more proper fix for phaxio until then.
