### PR TITLE
Small Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "main": "./phaxio.js",
   "dependencies": {
-  	"request": "2.16.x",
+  	"request": "2.67.x",
   	"mime": "1.2.x"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,15 @@ phaxio.sendFax({
 });
 ```
 
+### phaxio.cancelFax(faxId, callback)
+
+Cancels the fax `faxId`
+```javascript
+phaxio.cancelFax('123456', function(err, res) {
+  console.log(res);
+});
+```
+
 ### phaxio.faxStatus(faxId, callback)
 
 Returns the status of `faxId`


### PR DESCRIPTION
- Add `cancelFax` for Phaxio's `/faxCancel` endpoint
- Add `cancelFax` to `readme.md`
- Ensure numbers and booleans are properly attached to requests by sending them as strings. Numbers were not being sent to Phaxio. Booleans caused the request library to throw errors (possibly related: request/request#1693).
- Trim file names to just the name when sending to Phaxio to avoid leaking system paths, possibly make requests smaller, and to match browser behavior
- Rename `responceCb` to `responseCb`
- Bump request version to latest