### PR TITLE
Small Updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "main": "./phaxio.js",
   "dependencies": {
-  	"request": "2.16.x",
+  	"request": "2.67.x",
   	"mime": "1.2.x"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -84,6 +84,15 @@ phaxio.sendFax({
 });
 ```
 
+### phaxio.cancelFax(faxId, callback)
+
+Cancels the fax `faxId`
+```javascript
+phaxio.cancelFax('123456', function(err, res) {
+  console.log(res);
+});
+```
+
 ### phaxio.faxStatus(faxId, callback)
 
 Returns the status of `faxId`


### PR DESCRIPTION
This is a rebase of #10 by @studiochris

- Add cancelFax for Phaxio's /faxCancel endpoint
- Ensure numbers and booleans are properly attached to requests by sending them as strings (possibly related: request/issues#1693)
- Trim file names to just the name when sending to Phaxio, just as a browser would do, and to avoid leaking system paths
- Rename responceCb to responseCb
- Update request version
- Add cancelFax to readme