### PR TITLE
Update to request 2.81.0 to prevent RangeError

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "main": "./phaxio.js",
   "dependencies": {
-    "request": "2.67.x",
+    "request": "2.81.x",
     "mime": "1.2.x"
   }
 }


### PR DESCRIPTION
Update to request 2.81.0 to prevent RangeError when "to" phone number (or any part of the request) is numeric.

Ex: To replicate issue, attempt to send a fax to 3335552424 rather than '333-555-2424'

Prior to this version of request module, it would call `new Buffer(3335552424)` and `new Buffer('333-555-2424')` which depending on the parameter type would have a very different outcome. see https://nodejs.org/api/buffer.html